### PR TITLE
Update `regex` to version `2021.11.2`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.8.3" %}
+{% set version = "2021.11.2" %}
 
 package:
   name: regex
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/r/regex/regex-{{ version }}.tar.gz
-  sha256: 8935937dad2c9b369c3d932b0edbc52a62647c2afb2fafc0c280f14a8bf56a6a
+  sha256: 5e85dcfc5d0f374955015ae12c08365b565c6f1eaf36dd182476a4d8e5a1cdb7
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [win and py27]
+  # the minimal version of python supported is python 3.6
+  skip: true  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
 
 about:
   home: https://bitbucket.org/mrabarnett/mrab-regex
-  license: Apache 2.0
+  license: Apache-2.0
   license_family: Apache
   license_file: LICENSE.txt
   summary: Alternative regular expression module, to replace re


### PR DESCRIPTION

  `regex` version `2021.11.2`
1. - [x] check the upstream
    https://bitbucket.org/mrabarnett/mrab-regex/src/hg/

2. - [x] check the pinnings
    https://bitbucket.org/mrabarnett/mrab-regex/src/hg/setup.py

    - minimal version of python supported is `python 3.6`

    https://bitbucket.org/mrabarnett/mrab-regex/src/hg/setup.py#lines-28

3. - [x] check the changelogs
     the changelog file is not available in the upstream, however, we have the commits available. 

     https://bitbucket.org/mrabarnett/mrab-regex/commits/

4. - [x] additional research
    https://github.com/conda-forge/regex-feedstock/issues

There are currently no open issues mentioned in conda forge at the time of the review

5. - [x] verify dev_url
    https://bitbucket.org/mrabarnett/mrab-regex/src/hg/

6. - [x] verify doc_url
    https://bitbucket.org/mrabarnett/mrab-regex/src/hg/docs/Features.rst

7. - [x] license is spdx compliant

    `Apache-2.0`
    https://spdx.org/licenses/Apache-2.0.html

8. - [x] license family
     * Apache
9. - [x] verify the build number
     * build number is zero
10. - [x] verify setuptools
      * `setuptools` is in the recipe
11. - [x] verify wheel
      * `wheel` is in the recipe
12. - [x] pip in the test section
      * `pip` is in the test section
13. - [x] veriy the test section
      * the `test section` was verified
Results:
-


Based on the research findings and the results we can conclude
that it is safe to update `regex` to version `2021.11.2`
