### PR TITLE
regex 2022.3.15

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.11.2" %}
+{% set version = "2022.3.15" %}
 
 package:
   name: regex
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/r/regex/regex-{{ version }}.tar.gz
-  sha256: 5e85dcfc5d0f374955015ae12c08365b565c6f1eaf36dd182476a4d8e5a1cdb7
+  sha256: 0a7b75cc7bb4cc0334380053e4671c560e31272c9d2d5a6c4b8e9ae2c9bd0f82
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,15 +33,14 @@ test:
   commands:
     - pip check
 
-
 about:
-  home: https://bitbucket.org/mrabarnett/mrab-regex
+  home: https://github.com/mrabarnett/mrab-regex
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE.txt
   summary: Alternative regular expression module, to replace re
-  doc_url: https://bitbucket.org/mrabarnett/mrab-regex/src/hg/docs/Features.rst
-  dev_url: https://bitbucket.org/mrabarnett/mrab-regex/src/hg/
+  doc_url: https://github.com/mrabarnett/mrab-regex/blob/hg/README.rst
+  dev_url: https://github.com/mrabarnett/mrab-regex
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update regex to 2022.3.15

License: https://github.com/mrabarnett/mrab-regex/blob/hg/LICENSE.txt
Requirements: https://github.com/mrabarnett/mrab-regex/blob/hg/setup.py

No changes