### PR TITLE
[PKG-2872] regex 2023.10.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,19 @@
 {% set name = "regex" %}
-{% set version = "2022.7.9" %}
-{% set build_number = "0" %}
-{% set checksum = "601c99ac775b6c89699a48976f3dbb000b47d3ca59362c8abc9582e6d0780d91" %}
+{% set version = "2023.10.3" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/r/regex/regex-{{ version }}.tar.gz
-  sha256: {{ checksum }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 3fef4f844d2290ee0ba57addcec17eec9e3df73f10a2748485dfd6a3a188cc0f
 
 build:
-  number: {{ build_number }}
-  # the minimal version of python supported is python 3.6
-  skip: true  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 0
+  # the minimal version of python supported is python 3.7
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:
@@ -35,6 +33,7 @@ test:
     - pip
   commands:
     - pip check
+    - python -m unittest -v regex.test_regex
 
 about:
   home: https://github.com/mrabarnett/mrab-regex
@@ -42,6 +41,9 @@ about:
   license_family: Apache
   license_file: LICENSE.txt
   summary: Alternative regular expression module, to replace re
+  description: |
+    This regex implementation is backwards-compatible with the standard 're' module, 
+    but offers additional functionality.
   doc_url: https://github.com/mrabarnett/mrab-regex/blob/hg/README.rst
   dev_url: https://github.com/mrabarnett/mrab-regex
 


### PR DESCRIPTION
Changelog: https://github.com/mrabarnett/mrab-regex/blob/2023.10.3/changelog.txt
License: https://github.com/mrabarnett/mrab-regex/blob/2023.10.3/LICENSE.txt
Requirements:
- https://github.com/mrabarnett/mrab-regex/blob/2023.10.3/pyproject.toml
- https://github.com/mrabarnett/mrab-regex/blob/2023.10.3/setup.py

Actions:
1. Clean up the recipe
2. Skip `py<37`
3. Add `--no-build-isolation` to stript
4. Add tests: `python -m unittest -v regex.test_regex`
5. Add `description`


Notes:
- To enable python 3.12 support ![versions](https://img.shields.io/pypi/pyversions/regex.svg), see https://github.com/mrabarnett/mrab-regex/commit/bc73ebb5d794668fe272c6f869cfa01add91ed83#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R30

