### PR TITLE
[PKG-3111] regex 2023.8.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "regex" %}
-{% set version = "2023.10.3" %}
+{% set version = "2023.8.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3fef4f844d2290ee0ba57addcec17eec9e3df73f10a2748485dfd6a3a188cc0f
+  sha256: fcbdc5f2b0f1cd0f6a56cdb46fe41d2cce1e644e3b68832f3eeebc5fb0f7712e
 
 build:
   number: 0


### PR DESCRIPTION
Building the specific version **2023.8.8** against the `main-2023.8.8` branch

Changelog: https://github.com/mrabarnett/mrab-regex/blob/2023.8.8/changelog.txt
License: https://github.com/mrabarnett/mrab-regex/blob/2023.8.8/LICENSE.txt
Requirements:
- https://github.com/mrabarnett/mrab-regex/blob/2023.8.8/pyproject.toml
- https://github.com/mrabarnett/mrab-regex/blob/2023.8.8/setup.py

No changes