### PR TITLE
regex 2024.9.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "regex" %}
-{% set version = "2024.7.24" %}
+{% set version = "2024.9.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9cfd009eed1a46b27c14039ad5bbc5e71b6367c5b2e6d5f5da0ea91600817506
+  sha256: 6c188c307e8433bcb63dc1915022deb553b4203a70722fc542c363bf120a01fd
 
 build:
   number: 0


### PR DESCRIPTION
regex 2024.9.11

**Destination channel:** defaults

### Links

- [PKG-4762]
- dev_url (pypi): https://github.com/mrabarnett/mrab-regex/tree/2024.9.11
- diff: https://github.com/mrabarnett/mrab-regex/compare/2024.7.24...2024.9.11
- conda-forge: https://github.com/conda-forge/regex-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/regex/2024.9.11
- pypi inspector: https://inspector.pypi.io/project/regex/2024.9.11

### Explanation of changes:

- bump version, no changes


[PKG-4762]: https://anaconda.atlassian.net/browse/PKG-4762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ